### PR TITLE
Fixing visibility for attributes

### DIFF
--- a/src/Setup/Products/CreateProductAttributes.php
+++ b/src/Setup/Products/CreateProductAttributes.php
@@ -138,6 +138,7 @@ class CreateProductAttributes
                         'apply_to' => implode(',', [Type::TYPE_SIMPLE, Type::TYPE_VIRTUAL]),
                         'is_used_in_grid' => true,
                         'is_visible_in_grid' => false,
+                        'used_in_product_listing' => $data['used_in_product_listing'] ?? false,
                         'option' => [
                             'values' => $optionValues
                         ]

--- a/src/Setup/Products/UpdateProductAttributes.php
+++ b/src/Setup/Products/UpdateProductAttributes.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ScandiPWA_SampleData
+ *
+ * @category    Scandiweb
+ * @package     ScandiPWA_SampleData
+ * @author      Vadims Petrovs <info@scandiweb.com>
+ * @copyright   Copyright (c) 2020 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+namespace ScandiPWA\SampleData\Setup\Products;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Setup\SetupInterface;
+use ScandiPWA\SampleData\Helper\FileParser;
+use Magento\Eav\Setup\EavSetupFactory;
+
+class UpdateProductAttributes
+{
+    const PATH = 'products/attribute-update.json';
+
+    /**
+     * @var FileParser
+     */
+    private $fileParser;
+
+    /**
+     * @var EavSetupFactory
+     */
+    private $eavSetupFactory;
+
+    /**
+     * @param FileParser $fileParser
+     * @param EavSetupFactory $eavSetupFactory
+     */
+    public function __construct(
+        FileParser $fileParser,
+        EavSetupFactory $eavSetupFactory
+
+    ){
+        $this->fileParser = $fileParser;
+        $this->eavSetupFactory = $eavSetupFactory;
+    }
+
+    /**
+     * Applies migration.
+     *
+     * @param SetupInterface $setup
+     */
+    public function apply(SetupInterface $setup = null)
+    {
+        foreach ($this->fileParser->getJSONContent(self::PATH) as $attributeCode => $data) {
+            if ($data) {
+                $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+                $eavSetup->updateAttribute(Product::ENTITY, $attributeCode, $data);
+            }
+        }
+    }
+}

--- a/src/Setup/UpgradeData.php
+++ b/src/Setup/UpgradeData.php
@@ -11,6 +11,7 @@
 
 namespace ScandiPWA\SampleData\Setup;
 
+use ScandiPWA\SampleData\Setup\Products\UpdateProductAttributes;
 use ScandiPWA\SampleData\Setup\System\SetConfig;
 use ScandiPWA\SampleData\Setup\Categories\CreateCategories;
 use ScandiPWA\SampleData\Setup\Products\CreateProducts;
@@ -31,6 +32,7 @@ class UpgradeData extends AbstractUpgradeData
         '0.0.5' => CreateProductAttributes::class,
         '0.0.6' => CreateProducts::class,
         '0.0.7' => CreateMenu::class,
-        '0.0.8' => AddSlider::class
+        '0.0.8' => AddSlider::class,
+        '0.0.9' => UpdateProductAttributes::class
     ];
 }

--- a/src/files/data/json/products/attribute-update.json
+++ b/src/files/data/json/products/attribute-update.json
@@ -1,0 +1,29 @@
+{
+    "status": {
+        "used_in_product_listing": 0
+    },
+    "name": {
+        "used_in_product_listing": 0
+    },
+    "price": {
+        "used_in_product_listing": 0
+    },
+    "tax_class_id": {
+        "used_in_product_listing": 0
+    },
+    "short_description": {
+        "used_in_product_listing": 0
+    },
+    "image": {
+        "used_in_product_listing": 0
+    },
+    "small_image": {
+        "used_in_product_listing": 0
+    },
+    "thumbnail": {
+        "used_in_product_listing": 0
+    },
+    "url_key": {
+        "used_in_product_listing": 0
+    }
+}

--- a/src/files/data/json/products/attributes.json
+++ b/src/files/data/json/products/attributes.json
@@ -6,6 +6,7 @@
     "attribute_set_id": 4,
     "attribute_group": "Product Details",
     "is_visible_on_front": 1,
+    "used_in_product_listing": 1,
     "values" : {
       "brown" : {
         "default_store_view" : "Brown",
@@ -40,6 +41,7 @@
     "attribute_set_id": 4,
     "attribute_group": "Product Details",
     "is_visible_on_front": 1,
+    "used_in_product_listing": 1,
     "values" : {
       "xs" : {
         "default_store_view" : "Extra small size",


### PR DESCRIPTION
1. Added "used_in_product_listing" for attributes "color" & "size", thus enabling visibility in PDP
2. Added new patch file that edits existing attributes, thus hiding visibility in PDP.