### PR TITLE
Fix category anchor attribute

### DIFF
--- a/src/Setup/Categories/CreateCategories.php
+++ b/src/Setup/Categories/CreateCategories.php
@@ -108,6 +108,7 @@ class CreateCategories
             $categoryTmp->setImage($data['image'], $mediaAttribute, true, false);
             $categoryTmp->setPath($rootCategory->getPath());
             $categoryTmp->setDisplayMode('PRODUCTS_AND_PAGE');
+            $categoryTmp->setIsAnchor(1);
             $categoryTmp->save();
         }
     }


### PR DESCRIPTION
After category is created in DB there is no anchor attribute. This lead to getting null on FE -> no filters on category, but in admin panel on category we see that anchor is ON.