### PR TITLE
Replace div with span in <a> tags

### DIFF
--- a/src/files/data/html/cms-blocks/footer-links.html
+++ b/src/files/data/html/cms-blocks/footer-links.html
@@ -25,19 +25,19 @@
 			<h3 class="Footer-ColumnTitle">Follow</h3>
 			<div class="Footer-ColumnContent Footer-ColumnContent_direction_horizontal">
 				<a href="https://www.linkedin.com/company/scandipwa" class=" Footer-ColumnItem Footer-ColumnItem_type_image">
-					<div class="Image Image_ratio_square Image_imageStatus_1 Image_hasSrc Footer-ColumnItemImage">
+					<span class="Image Image_ratio_square Image_imageStatus_1 Image_hasSrc Footer-ColumnItemImage">
 						<img src="{{media url="wysiwyg/social/linkedin.png"}}" alt="" loading="lazy" class="Image-Image" style="width: 100%; height: 100%; z-index: 1">
-					</div>
+					</span>
 				</a>
 				<a href="https://www.youtube.com/channel/UCvnxo7rh5NRwvMHtJga9fww" class=" Footer-ColumnItem Footer-ColumnItem_type_image">
-					<div class="Image Image_ratio_square Image_imageStatus_1 Image_hasSrc Footer-ColumnItemImage ">
+					<span class="Image Image_ratio_square Image_imageStatus_1 Image_hasSrc Footer-ColumnItemImage ">
 						<img src="{{media url="wysiwyg/social/youtube.png"}}" alt="" loading="lazy" class="Image-Image" style="width: 100%; height: 100%; z-index: 1">
-					</div>
+					</span>
 				</a>
 				<a href="https://twitter.com/scandipwa" class=" Footer-ColumnItem Footer-ColumnItem_type_image">
-					<div class="Image Image_ratio_square Image_imageStatus_1 Image_hasSrc Footer-ColumnItemImage ">
+					<span class="Image Image_ratio_square Image_imageStatus_1 Image_hasSrc Footer-ColumnItemImage ">
 						<img src="{{media url="wysiwyg/social/twitter.png"}}" alt="" loading="lazy" class="Image-Image" style="width: 100%; height: 100%; z-index: 1">
-					</div>
+					</span>
 				</a>
 			</div>
 		</div>


### PR DESCRIPTION
<div> tags are (officially) not valid inside <a> tags, as they are not in-line elements. So magento editor removes <a> tags from block when user saves it.