### PR TITLE
2.4.4 update - changed the type of the third argument in savePage and saveBlock

### DIFF
--- a/src/Helper/Cms.php
+++ b/src/Helper/Cms.php
@@ -179,10 +179,11 @@ class Cms
      */
     protected function saveBlock(Block $cmsBlock): Block
     {
+        $cms_block = [$cmsBlock];
         $this->appState->emulateAreaCode(
             self::AREA_CODE,
             [$this->blockResource, 'save'],
-            ['cms_block' => $cmsBlock]
+            $cms_block
         );
 
         return $cmsBlock;
@@ -194,10 +195,11 @@ class Cms
      */
     protected function savePage(Page $cmsPage): Page
     {
+        $cms_page = [$cmsPage];
         $this->appState->emulateAreaCode(
             self::AREA_CODE,
             [$this->pageResource, 'save'],
-            ['cms_page' => $cmsPage]
+            $cms_page
         );
 
         return $cmsPage;

--- a/src/Helper/Cms.php
+++ b/src/Helper/Cms.php
@@ -179,11 +179,10 @@ class Cms
      */
     protected function saveBlock(Block $cmsBlock): Block
     {
-        $cms_block = [$cmsBlock];
         $this->appState->emulateAreaCode(
             self::AREA_CODE,
             [$this->blockResource, 'save'],
-            $cms_block
+            [$cmsBlock]
         );
 
         return $cmsBlock;
@@ -195,11 +194,10 @@ class Cms
      */
     protected function savePage(Page $cmsPage): Page
     {
-        $cms_page = [$cmsPage];
         $this->appState->emulateAreaCode(
             self::AREA_CODE,
             [$this->pageResource, 'save'],
-            $cms_page
+            [$cmsPage]
         );
 
         return $cmsPage;


### PR DESCRIPTION
**Problem:**
* The module wasn't working because magento's emulateAreaCode's third argument's type definition changed in the 2.4.4 version, resulting in errors.

**In this PR:**
* Updated the type of value supplied from our module to correspond with the new specification.
